### PR TITLE
Mount the directory containing the CRI socket instead of the socket itself

### DIFF
--- a/stable/datadog/templates/container-agent.yaml
+++ b/stable/datadog/templates/container-agent.yaml
@@ -91,7 +91,7 @@
     {{- end }}
     {{- if .Values.datadog.criSocketPath }}
     - name: DD_CRI_SOCKET_PATH
-      value: {{ .Values.datadog.criSocketPath }}
+      value: {{ print "/host/" .Values.datadog.criSocketPath | clean }}
     {{- end }}
     {{- if not .Values.datadog.livenessProbe }}
     - name: DD_HEALTH_PORT
@@ -117,8 +117,8 @@
       subPath: datadog.yaml
     {{- end }}
     {{- if .Values.datadog.criSocketPath }}
-    - name: runtimesocket
-      mountPath: {{ .Values.datadog.criSocketPath }}
+    - name: runtimesocketdir
+      mountPath: {{ print "/host/" (dir .Values.datadog.criSocketPath) | clean }}
       readOnly: true
     {{- end }}
     {{- if .Values.datadog.dogstatsd.useSocketVolume }}

--- a/stable/datadog/templates/container-process-agent.yaml
+++ b/stable/datadog/templates/container-process-agent.yaml
@@ -37,8 +37,8 @@
       mountPath: /host/proc
       readOnly: true
     {{- if .Values.datadog.criSocketPath }}
-    - name: runtimesocket
-      mountPath: {{ .Values.datadog.criSocketPath }}
+    - name: runtimesocketdir
+      mountPath: {{ print "/host/" (dir .Values.datadog.criSocketPath) | clean }}
       readOnly: true
     {{- end }}
     {{- if .Values.datadog.systemProbe.enabled }}

--- a/stable/datadog/templates/containers-init.yaml
+++ b/stable/datadog/templates/containers-init.yaml
@@ -29,8 +29,8 @@
       mountPath: /host/proc
       readOnly: true
     {{- if .Values.datadog.criSocketPath }}
-    - name: runtimesocket
-      mountPath: {{ .Values.datadog.criSocketPath }}
+    - name: runtimesocketdir
+      mountPath: {{ print "/host/" (dir .Values.datadog.criSocketPath) | clean }}
       readOnly: true
     {{- end }}
   env:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -79,8 +79,8 @@ spec:
           emptyDir: {}
         {{- if .Values.datadog.criSocketPath }}
         - hostPath:
-            path: {{ .Values.datadog.criSocketPath }}
-          name: runtimesocket
+            path: {{ dir .Values.datadog.criSocketPath }}
+          name: runtimesocketdir
         {{- end }}
         {{- if .Values.datadog.dogstatsd.useSocketVolume }}
         - hostPath:


### PR DESCRIPTION
This is to handle the cases where the docker daemon is restarted.
In this case, the docker daemon will recreate its docker socket and,
if the container bind-mounted directly the socket, the container would
still have access to the old socket instead of the one of the new docker
daemon.